### PR TITLE
Raster zerosLike method

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -62,12 +62,15 @@ install(EXPORT ${projectName}Targets
 
 install(DIRECTORY ${projectName}/
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/${projectName}/
-    FILES_MATCHING PATTERN "*.h*"
+    FILES_MATCHING 
+        PATTERN "*.h*"
 )
 
 install(DIRECTORY ${EXTERNAL_INSTALL_LOCATION}/include/
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/
-    FILES_MATCHING PATTERN "*.h*"
+    FILES_MATCHING 
+        PATTERN "*.h*"
+        PATTERN "*.ipp"
 )
 
 # Define KILIB_RESOURCE_PATH

--- a/KiLib/Raster/Raster.cpp
+++ b/KiLib/Raster/Raster.cpp
@@ -144,7 +144,7 @@ namespace KiLib
       }
    }
 
-  void Raster::writeToFile(std::string path) const
+   void Raster::writeToFile(std::string path) const
    {
       std::ofstream outFile = std::ofstream(path);
       if (!outFile.is_open()) {
@@ -186,6 +186,13 @@ namespace KiLib
       pos.z = this->getInterpBilinear(pos);
 
       return pos;
-
    }
+
+   KiLib::Raster zerosLike(const KiLib::Raster &other)
+   {
+      KiLib::Raster new_(other);
+      std::fill(new_.data.begin(), new_.data.end(), 0.0);
+      return new_;
+   }
+
 } // namespace KiLib

--- a/KiLib/Raster/Raster.cpp
+++ b/KiLib/Raster/Raster.cpp
@@ -187,12 +187,4 @@ namespace KiLib
 
       return pos;
    }
-
-   KiLib::Raster zerosLike(const KiLib::Raster &other)
-   {
-      KiLib::Raster new_(other);
-      std::fill(new_.data.begin(), new_.data.end(), 0.0);
-      return new_;
-   }
-
 } // namespace KiLib

--- a/KiLib/Raster/Raster.hpp
+++ b/KiLib/Raster/Raster.hpp
@@ -38,7 +38,12 @@ namespace KiLib
       Raster();
 
       // Creates a raster filled with zeros with same metadata as other.
-      static KiLib::Raster zerosLike(const KiLib::Raster &other);
+      static KiLib::Raster zerosLike(const KiLib::Raster &other)
+      {
+         KiLib::Raster new_(other);
+         std::fill(new_.data.begin(), new_.data.end(), 0.0);
+         return new_;
+      }
 
 
       void writeToFile(std::string path) const;

--- a/KiLib/Raster/Raster.hpp
+++ b/KiLib/Raster/Raster.hpp
@@ -37,6 +37,10 @@ namespace KiLib
       Raster(std::string path);
       Raster();
 
+      // Creates a raster filled with zeros with same metadata as other.
+      static KiLib::Raster zerosLike(const KiLib::Raster &other);
+
+
       void writeToFile(std::string path) const;
 
       /**


### PR DESCRIPTION
Closes #4 . Adds a static method that constructs a Raster filled with zeros with the same metadata as a provided raster. Includes #2 