### PR TITLE
Issue10 | Raster cleanups

### DIFF
--- a/KiLib/Raster/Raster.cpp
+++ b/KiLib/Raster/Raster.cpp
@@ -1,6 +1,7 @@
 #include <KiLib/Raster/Raster.hpp>
 #include <spdlog/fmt/ostr.h>
 #include <spdlog/spdlog.h>
+#include <stats.hpp>
 
 namespace KiLib
 {
@@ -181,8 +182,8 @@ namespace KiLib
    KiLib::Vec3 Raster::randPoint()
    {
       KiLib::Vec3 pos(
-         ((double)rand() / (double)RAND_MAX) * this->width, ((double)rand() / (double)RAND_MAX) * this->height, 0);
-
+         stats::runif(this->xllcorner, this->xllcorner + this->width),
+         stats::runif(this->yllcorner, this->yllcorner + this->height), 0);
       pos.z = this->getInterpBilinear(pos);
 
       return pos;

--- a/KiLib/Raster/Raster.cpp
+++ b/KiLib/Raster/Raster.cpp
@@ -182,8 +182,7 @@ namespace KiLib
    KiLib::Vec3 Raster::randPoint()
    {
       KiLib::Vec3 pos(
-         stats::runif(this->xllcorner, this->xllcorner + this->width),
-         stats::runif(this->yllcorner, this->yllcorner + this->height), 0);
+         ((double)rand() / (double)RAND_MAX) * this->width, ((double)rand() / (double)RAND_MAX) * this->height, 0);
       pos.z = this->getInterpBilinear(pos);
 
       return pos;

--- a/KiLib/Raster/Raster.cpp
+++ b/KiLib/Raster/Raster.cpp
@@ -1,7 +1,6 @@
 #include <KiLib/Raster/Raster.hpp>
 #include <spdlog/fmt/ostr.h>
 #include <spdlog/spdlog.h>
-#include <stats.hpp>
 
 namespace KiLib
 {

--- a/KiLib/Raster/Raster.cpp
+++ b/KiLib/Raster/Raster.cpp
@@ -57,14 +57,14 @@ namespace KiLib
 
       this->data.resize(nRows * nCols);
       // Load elevations
-      for (int row = 0; row < this->nRows; row++) {
+      for (size_t row = 0; row < this->nRows; row++) {
          getline(rasterFile, line);
          stream.str(line);
          stream.clear();
 
          // Moving along a row (across columns) is movement through X
          // Moving down a column (across rows) is movement through Y
-         for (int col = 0; col < this->nCols; col++) {
+         for (size_t col = 0; col < this->nCols; col++) {
             double value;
             stream >> value;
             this->at(this->nRows - row - 1, col) = value;
@@ -130,8 +130,8 @@ namespace KiLib
          "NODATA_value {}\n",
          this->nCols, this->nRows, this->xllcorner, this->yllcorner, this->cellsize, this->nodata_value);
 
-      for (int row = (this->nRows - 1); row >= 0; row--) {
-         for (int col = 0; col < this->nCols; col++) {
+      for (size_t row = (this->nRows - 1); row >= 0; row--) {
+         for (size_t col = 0; col < this->nCols; col++) {
             double val = this->operator()(row, col);
 
             if (val == this->nodata_value) {
@@ -162,8 +162,8 @@ namespace KiLib
          "NODATA_value {}\n",
          this->nCols, this->nRows, this->xllcorner, this->yllcorner, this->cellsize, this->nodata_value);
 
-      for (int row = (this->nRows - 1); row >= 0; row--) {
-         for (int col = 0; col < this->nCols; col++) {
+      for (size_t row = (this->nRows - 1); row >= 0; row--) {
+         for (size_t col = 0; col < this->nCols; col++) {
             double val = this->operator()(row, col);
 
             if (val == this->nodata_value) {

--- a/KiLib/Raster/Raster.cpp
+++ b/KiLib/Raster/Raster.cpp
@@ -131,9 +131,9 @@ namespace KiLib
          "NODATA_value {}\n",
          this->nCols, this->nRows, this->xllcorner, this->yllcorner, this->cellsize, this->nodata_value);
 
-      for (size_t row = (this->nRows - 1); row >= 0; row--) {
+      for (size_t row = 1; row <= this->nRows; row++) {
          for (size_t col = 0; col < this->nCols; col++) {
-            double val = this->operator()(row, col);
+            double val = this->operator()(this->nRows - row, col);
 
             if (val == this->nodata_value) {
                fmt::print("{} ", this->nodata_value);
@@ -163,9 +163,9 @@ namespace KiLib
          "NODATA_value {}\n",
          this->nCols, this->nRows, this->xllcorner, this->yllcorner, this->cellsize, this->nodata_value);
 
-      for (size_t row = (this->nRows - 1); row >= 0; row--) {
+      for (size_t row = 1; row <= this->nRows; row++) {
          for (size_t col = 0; col < this->nCols; col++) {
-            double val = this->operator()(row, col);
+            double val = this->operator()(this->nRows - row, col);
 
             if (val == this->nodata_value) {
                fmt::print(outFile, "{} ", this->nodata_value);

--- a/KiLib/Raster/Raster.hpp
+++ b/KiLib/Raster/Raster.hpp
@@ -23,15 +23,16 @@ namespace KiLib
    public:
       std::vector<double> data;
 
-      double xllcorner; // Lower left corner x value in absolute coordinates
-      double yllcorner; // Lower left corner y value in absolute coordinates
-      double cellsize;  // [m] Distance between values
-      double width;     // [m] Width in X
-      double height;    // [m] Height in Y
+      double xllcorner;    // Lower left corner x value in absolute coordinates
+      double yllcorner;    // Lower left corner y value in absolute coordinates
+      double cellsize;     // [m] Distance between values
+      double width;        // [m] Width in X
+      double height;       // [m] Height in Y
+      double nodata_value; // Value associated with no data from DEM
 
-      int nCols;        // Number of columns (x)
-      int nRows;        // Number of rows (y)
-      int nodata_value; // Value associated with no data from DEM
+      size_t nCols; // Number of columns (x)
+      size_t nRows; // Number of rows (y)
+
       bool constructed; // Flag indicating whether a file was loaded
 
       Raster(std::string path);


### PR DESCRIPTION
Moved from `int` to `size_t` for things are unsigned. NODATA is now a double. Fixed an underflow with `size_t`. Closes #10 
