### PR TITLE
Rename CMake Project

### DIFF
--- a/CMake/GitPreCommitHook.cmake.in
+++ b/CMake/GitPreCommitHook.cmake.in
@@ -1,0 +1,7 @@
+### git commit hook setup
+add_custom_command(
+  TARGET ${projectNameStatic}
+  PRE_BUILD
+  COMMAND git config core.hooksPath .githooks
+  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+)

--- a/CMake/GitPreCommitHook.cmake.in
+++ b/CMake/GitPreCommitHook.cmake.in
@@ -1,7 +1,0 @@
-### git commit hook setup
-add_custom_command(
-  TARGET ${projectName}
-  PRE_BUILD
-  COMMAND git config core.hooksPath .githooks
-  WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
-)

--- a/CMake/gcem.cmake.in
+++ b/CMake/gcem.cmake.in
@@ -14,11 +14,11 @@ FetchContent_Populate(
   QUIET
   GIT_REPOSITORY  https://github.com/kthohr/gcem
   GIT_TAG         v1.13.1
-  SOURCE_DIR      ${CMAKE_SOURCE_DIR}/lib/gcem
+  SOURCE_DIR      gcem_proj
 )
  
 # Add GCEM to this build
-add_subdirectory(${gcem_proj_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/lib/gcem)
+add_subdirectory(${gcem_proj_SOURCE_DIR} gcem_proj)
 
 # Add the include directory from this project
 include_directories(${gcem_proj_SOURCE_DIR}/include)

--- a/CMake/libtiff.cmake.in
+++ b/CMake/libtiff.cmake.in
@@ -6,9 +6,9 @@ FetchContent_Populate(
 	QUIET
 	GIT_REPOSITORY https://github.com/CoSci-LLC/libtiff
 	GIT_TAG        only_lib
-	SOURCE_DIR     ${CMAKE_SOURCE_DIR}/lib/libtiff
+	SOURCE_DIR     libtiff_proj
 )
 
-add_subdirectory(${libtiff_proj_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/lib/libtiff/build)
+add_subdirectory(${libtiff_proj_SOURCE_DIR} libtiff_proj/build)
 include_directories(${libtiff_proj_SOURCE_DIR} ${CMAKE_INSTALL_PREFIX}/include)
 target_link_libraries(${projectName} PUBLIC tiff)

--- a/CMake/spdlog.cmake.in
+++ b/CMake/spdlog.cmake.in
@@ -13,11 +13,11 @@ FetchContent_Populate(
   QUIET
   GIT_REPOSITORY  https://github.com/gabime/spdlog.git
   GIT_TAG         v1.8.2
-  SOURCE_DIR      ${CMAKE_SOURCE_DIR}/lib/spdlog
+  SOURCE_DIR      spdlog_proj
 )
 
 # Add this to the current build
-add_subdirectory(${spdlog_proj_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/lib/spdlog/build)
+add_subdirectory(${spdlog_proj_SOURCE_DIR} spdlog_proj/build)
 
 # Add the include directory into this project
 include_directories(${spdlog_proj_SOURCE_DIR} ${CMAKE_INSTALL_PREFIX}/include)

--- a/CMake/stats.cmake.in
+++ b/CMake/stats.cmake.in
@@ -15,7 +15,7 @@ FetchContent_Populate(
   QUIET
   GIT_REPOSITORY  https://github.com/kthohr/stats
   GIT_TAG         v3.1.1
-  SOURCE_DIR      ${CMAKE_SOURCE_DIR}/lib/stats
+  SOURCE_DIR      stats_proj
 )
  
 # Stats is special because it doesn't include a cmake project.

--- a/CMake/yaml-cpp.cmake.in
+++ b/CMake/yaml-cpp.cmake.in
@@ -13,7 +13,7 @@ FetchContent_Populate(
   QUIET
   GIT_REPOSITORY  https://github.com/jbeder/yaml-cpp
   GIT_TAG         yaml-cpp-0.6.3
-  SOURCE_DIR      ${CMAKE_SOURCE_DIR}/lib/yamlcpp
+  SOURCE_DIR      yamlcpp_proj
 )
 
 # Disable yaml-cpp tests
@@ -23,7 +23,7 @@ set(YAML_CPP_BUILD_CONTRIB OFF CACHE BOOL "disable yaml contrib")
 
 
 # Add yaml-cpp to this project
-add_subdirectory(${yamlcpp_proj_SOURCE_DIR} ${CMAKE_SOURCE_DIR}/lib/yamlcpp/build)
+add_subdirectory(${yamlcpp_proj_SOURCE_DIR} yamlcpp_proj/build)
 
 # Include the headers into our project
 include_directories(${yamlcpp_proj_SOURCE_DIR} ${CMAKE_INSTALL_PREFIX}/include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,10 +20,9 @@ set_property(TARGET ${projectName} PROPERTY POSITION_INDEPENDENT_CODE 1)
 
 # shared and static libraries built from the same object files
 add_library(${projectNameShared} SHARED $<TARGET_OBJECTS:${projectName}>)
-
+target_link_libraries(${projectNameShared} PUBLIC ${projectName})
 
 add_library(${projectNameStatic} STATIC $<TARGET_OBJECTS:${projectName}>)
-set_target_properties(${projectNameStatic} PROPERTIES OUTPUT_NAME "kilib")
 target_link_libraries(${projectNameStatic} ${projectName})
 
 
@@ -40,9 +39,6 @@ endif()
 if (NOT CMAKE_BUILD_TYPE OR CMAKE_BUILD_TYPE STREQUAL "")
     set(CMAKE_BUILD_TYPE "Release" CACHE STRING "" FORCE)
 endif()
-
-
-
 
 # If we are debugging, add debug statements to every project
 if (CMAKE_BUILD_TYPE STREQUAL "Debug")
@@ -82,19 +78,7 @@ target_include_directories(${projectName}
         ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}
 )
 
-target_include_directories(${projectNameStatic}
-    PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-    PRIVATE
-        ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}
-)
 
-target_include_directories(${projectNameShared}
-    PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-    PRIVATE
-        ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}
-)
 
 # Define KILIB_RESOURCE_PATH
 target_compile_definitions(${projectName} PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,13 +3,11 @@
 cmake_minimum_required(VERSION 3.13)
 
 # Set the project and test app name
-set(projectName KiLibOSSObjLib)
-set(projectNameStatic KiLibOSS_static)
-set(projectNameShared KiLibOSS_shared)
-set(projectTestName ${projectName}.test)
+set(projectName KiLibObjLib)
+set(projectTestName KiLib.test)
 
 # Create the project name and version
-project(${projectName} VERSION 2.4.4 LANGUAGES CXX)
+project(KiLib VERSION 2.4.4 LANGUAGES CXX)
 
 
 # Add KiLib Object Library
@@ -19,14 +17,8 @@ add_library(${projectName} OBJECT "")
 set_property(TARGET ${projectName} PROPERTY POSITION_INDEPENDENT_CODE 1)
 
 # shared and static libraries built from the same object files
-add_library(${projectNameShared} SHARED $<TARGET_OBJECTS:${projectName}>)
-target_link_libraries(${projectNameShared} PUBLIC ${projectName})
-
-add_library(${projectNameStatic} STATIC $<TARGET_OBJECTS:${projectName}>)
-target_link_libraries(${projectNameStatic} PUBLIC ${projectName})
-
-
-set(CMAKE_POSITION_INDEPENDENT_CODE ON)
+add_library(KiLib STATIC $<TARGET_OBJECTS:${projectName}>)
+target_link_libraries(KiLib PUBLIC ${projectName})
 
 # Ensure that the install directory is all setup properly
 message("Install Directory: ${CMAKE_INSTALL_INCLUDEDIR}")
@@ -78,10 +70,9 @@ target_include_directories(${projectName}
 )
 
 install(TARGETS ${projectName} tiff spdlog
-        EXPORT KiLibOSSTargets
+        EXPORT KiLibTargets
         INCLUDES DESTINATION include
 )
-install(FILES KiLib/KiLib.hpp DESTINATION include/KiLib)
 
 # Define KILIB_RESOURCE_PATH
 target_compile_definitions(${projectName} PUBLIC
@@ -95,23 +86,18 @@ install(DIRECTORY
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/KiLib
 )
 
-install(EXPORT KiLibOSSTargets
-        FILE KiLibOSSTargets.cmake
+install(EXPORT KiLibTargets
+        FILE KiLibTargets.cmake
         NAMESPACE KiLib::
         DESTINATION lib/cmake
 )
 
-install(TARGETS ${projectNameStatic} 
-        EXPORT KiLibOSSTargets
+install(TARGETS KiLib 
+        EXPORT KiLibTargets
         RUNTIME DESTINATION bin
         LIBRARY DESTINATION lib  
 )
 
-install(TARGETS ${projectNameShared} 
-        EXPORT KiLibOSSTargets
-        RUNTIME DESTINATION bin
-        LIBRARY DESTINATION lib
-)
 
 # Define compiler options for each compiler
 if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,15 +3,29 @@
 cmake_minimum_required(VERSION 3.13)
 
 # Set the project and test app name
-set(projectName KiLib)
+set(projectName KiLibOSSObjLib)
+set(projectNameStatic KiLibOSS_static)
+set(projectNameShared KiLibOSS_shared)
 set(projectTestName ${projectName}.test)
 
 # Create the project name and version
 project(${projectName} VERSION 2.4.4 LANGUAGES CXX)
 
 
-# Add KiLib Library
-add_library(${projectName} STATIC "") 
+# Add KiLib Object Library
+add_library(${projectName} OBJECT "") 
+
+# shared libraries need PIC
+set_property(TARGET ${projectName} PROPERTY POSITION_INDEPENDENT_CODE 1)
+
+# shared and static libraries built from the same object files
+add_library(${projectNameShared} SHARED $<TARGET_OBJECTS:${projectName}>)
+
+
+add_library(${projectNameStatic} STATIC $<TARGET_OBJECTS:${projectName}>)
+set_target_properties(${projectNameStatic} PROPERTIES OUTPUT_NAME "kilib")
+target_link_libraries(${projectNameStatic} ${projectName})
+
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
@@ -68,6 +82,20 @@ target_include_directories(${projectName}
         ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}
 )
 
+target_include_directories(${projectNameStatic}
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    PRIVATE
+        ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+target_include_directories(${projectNameShared}
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    PRIVATE
+        ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}
+)
+
 # Define KILIB_RESOURCE_PATH
 target_compile_definitions(${projectName} PUBLIC
     KILIB_RESOURCE_PATH="${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/KiLib/resources"
@@ -85,12 +113,13 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     # using Clang
     message(STATUS "Clang detected, adding compile flags")
     target_compile_options(${projectName} PRIVATE -Wall -Werror)
+    
     # Enforce C++17 features
     target_compile_features(${projectName} PRIVATE cxx_std_17)
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # using GCC
     message(STATUS "GCC detected, adding compile flags")
-    target_compile_options(${projectName} PRIVATE -Wall -Werror)
+    target_compile_options(${projectName} PRIVATE -Wall -Werror )
     # Enforce C++17 features
     target_compile_features(${projectName} PRIVATE cxx_std_17)
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
@@ -98,6 +127,3 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     message(STATUS "msvc detected, adding compile flags")
     target_compile_options(${projectName} PRIVATE  /std:c++latest /EHsc)
 endif()
-
-# Git commit hook installation
-include(CMake/GitPreCommitHook.cmake.in)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,7 +23,7 @@ add_library(${projectNameShared} SHARED $<TARGET_OBJECTS:${projectName}>)
 target_link_libraries(${projectNameShared} PUBLIC ${projectName})
 
 add_library(${projectNameStatic} STATIC $<TARGET_OBJECTS:${projectName}>)
-target_link_libraries(${projectNameStatic} ${projectName})
+target_link_libraries(${projectNameStatic} PUBLIC ${projectName})
 
 
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
@@ -74,11 +74,14 @@ add_subdirectory(KiLib)
 target_include_directories(${projectName}
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-    PRIVATE
-        ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}
+        "$<INSTALL_INTERFACE:include>"
 )
 
-
+install(TARGETS ${projectName} tiff spdlog
+        EXPORT KiLibOSSTargets
+        INCLUDES DESTINATION include
+)
+install(FILES KiLib/KiLib.hpp DESTINATION include/KiLib)
 
 # Define KILIB_RESOURCE_PATH
 target_compile_definitions(${projectName} PUBLIC
@@ -89,7 +92,25 @@ target_compile_definitions(${projectName} PUBLIC
 message("Resource install location: ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR}/KiLib/resources")
 install(DIRECTORY
     ${CMAKE_CURRENT_SOURCE_DIR}/resources
-    DESTINATION ${CMAKE_INSTALL_LIBDIR}/${projectName}
+    DESTINATION ${CMAKE_INSTALL_LIBDIR}/KiLib
+)
+
+install(EXPORT KiLibOSSTargets
+        FILE KiLibOSSTargets.cmake
+        NAMESPACE KiLib::
+        DESTINATION lib/cmake
+)
+
+install(TARGETS ${projectNameStatic} 
+        EXPORT KiLibOSSTargets
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib  
+)
+
+install(TARGETS ${projectNameShared} 
+        EXPORT KiLibOSSTargets
+        RUNTIME DESTINATION bin
+        LIBRARY DESTINATION lib
 )
 
 # Define compiler options for each compiler

--- a/KiLib/Raster/Raster.cpp
+++ b/KiLib/Raster/Raster.cpp
@@ -172,6 +172,17 @@ namespace KiLib
       return r * this->nCols + c;
    }
 
+   KiLib::Vec3 Raster::getCellPos(size_t ind)
+   {
+      size_t r = this->nCols / ind;
+      size_t c = this->nCols % ind;
+
+      KiLib::Vec3 pos = KiLib::Vec3(this->xllcorner + c * this->cellsize, this->yllcorner + r * this->cellsize, 0);
+      pos.z           = this->getInterpBilinear(pos);
+
+      return pos;
+   }
+
    static const auto EnumToSlope =
       std::map<KiLib::Raster::SlopeMethod, std::function<KiLib::Raster(const KiLib::Raster &)>>{
          {KiLib::Raster::SlopeMethod::ZevenbergenThorne, KiLib::Raster::ComputeSlopeZevenbergenThorne},

--- a/KiLib/Raster/Raster.hpp
+++ b/KiLib/Raster/Raster.hpp
@@ -90,6 +90,8 @@ namespace KiLib
        */
       size_t getNearestCell(const KiLib::Vec3 &pos);
 
+      KiLib::Vec3 getCellPos(size_t ind);
+
       /**
        * @brief Returns distance between pos and nearest boundary point
        *

--- a/KiLib/Utils/Vec3.hpp
+++ b/KiLib/Utils/Vec3.hpp
@@ -72,7 +72,7 @@ namespace KiLib
       std::string toString() const
       {
          return "(" + std::to_string(this->x) + "," + std::to_string(this->y) + "," + std::to_string(this->z) + ")";
-      };
+      }
 
       static Vec3   cross(const Vec3 &a, const Vec3 &b);
       static Vec3   normalise(const Vec3 &a);

--- a/test/CMake/GoogleTest.cmake.in
+++ b/test/CMake/GoogleTest.cmake.in
@@ -5,8 +5,8 @@ include(ExternalProject)
 ExternalProject_Add(googletest
   GIT_REPOSITORY    https://github.com/google/googletest.git
   GIT_TAG           master
-  SOURCE_DIR        "${CMAKE_BINARY_DIR}/googletest-src"
-  BINARY_DIR        "${CMAKE_BINARY_DIR}/googletest-build"
+  SOURCE_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-src"
+  BINARY_DIR        "${CMAKE_CURRENT_BINARY_DIR}/googletest-build"
   CONFIGURE_COMMAND ""
   BUILD_COMMAND     ""
   INSTALL_COMMAND   ""

--- a/test/CMake/GoogleTestSetup.cmake.in
+++ b/test/CMake/GoogleTestSetup.cmake.in
@@ -2,16 +2,16 @@
 
 # Download and unpack googletest at configure time
 configure_file(CMake/GoogleTest.cmake.in googletest-download/CMakeLists.txt)
-message(${CMAKE_BINARY_DIR})
+message(${CMAKE_CURRENT_BINARY_DIR})
 execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
   RESULT_VARIABLE result
-  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/test/googletest-download )
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
 if(result)
   message(FATAL_ERROR "CMake step for googletest failed: ${result}")
 endif()
 execute_process(COMMAND ${CMAKE_COMMAND} --build .
   RESULT_VARIABLE result
-  WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/test/googletest-download )
+  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
 if(result)
   message(FATAL_ERROR "Build step for googletest failed: ${result}")
 endif()
@@ -22,8 +22,8 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 
 # Add googletest directly to our build. This defines
 # the gtest and gtest_main targets.
-add_subdirectory(${CMAKE_BINARY_DIR}/googletest-src
-                 ${CMAKE_BINARY_DIR}/googletest-build
+add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
+                 ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
                  EXCLUDE_FROM_ALL)
 
 # The gtest/gtest_main targets carry header search path

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,7 +37,7 @@ target_compile_definitions(${projectTestName} PUBLIC
 )
 
 # Link to the KiLib library
-target_link_libraries(${projectTestName} gtest_main KiLibOSS_static)
+target_link_libraries(${projectTestName} gtest_main KiLib)
 
 target_include_directories(${projectTestName}
 PUBLIC

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -6,7 +6,7 @@ include(CTest)
 include(GoogleTest)
 
 # Setup the test framework
-include(CMake/GoogleTestSetup.cmake.in)
+include(./CMake/GoogleTestSetup.cmake.in)
 
 # Add the test exe
 add_executable(${projectTestName}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -37,7 +37,7 @@ target_compile_definitions(${projectTestName} PUBLIC
 )
 
 # Link to the KiLib library
-target_link_libraries(${projectTestName} gtest_main KiLib)
+target_link_libraries(${projectTestName} gtest_main KiLibOSS_static)
 
 target_include_directories(${projectTestName}
 PUBLIC


### PR DESCRIPTION
This renames the CMake project that is exported. This will break other projects that rely on KiLib OSS, but it was necessary for updating KiLib with other changes. See the other PR for info.

This also adds the capability to generate a shared library. This is important for other projects that I am currently working on and I figured this wasn't a bad extra feature. 

For new projects to use KiLib OSS, they can use the target `KiLibOSS_static` or `KiLibOSS_shared` depending on what they need or want to use. 