### PR TITLE
issue56-57

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,19 @@
 
 Notable changes to this project will be documented in this file.
 
+## vX.X.X
+---
+### Added
+
+- Add flattenIndex method to Raster
+
+### Fixed
+
+- When compiling on windows we define _USE_MATH_DEFINES to make sure there are no math constant issues
+- getCellPos div by zero
+
 ## v2.5.0 (2020-03-03)
+---
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ Notable changes to this project will be documented in this file.
 ### Added
 
 - Add flattenIndex method to Raster
+- Add Rasterize method to raster
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ Notable changes to this project will be documented in this file.
 
 - Add flattenIndex method to Raster
 - Add Rasterize method to raster
+- Add GetAverage method to raster
 
 ### Fixed
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -116,5 +116,5 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
 elseif (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     # using Visual Studio C++
     message(STATUS "msvc detected, adding compile flags")
-    target_compile_options(${projectName} PRIVATE  /std:c++latest /EHsc)
+    target_compile_options(${projectName} PRIVATE  /std:c++latest /EHsc /D_USE_MATH_DEFINES)
 endif()

--- a/KiLib/Raster/Raster.cpp
+++ b/KiLib/Raster/Raster.cpp
@@ -37,7 +37,7 @@ namespace KiLib
    }
 
    // Load data in Raster format from specified path
-   Raster::Raster(std::string path)
+   Raster::Raster(const std::string &path)
    {
       this->constructed = false;
 
@@ -132,7 +132,7 @@ namespace KiLib
       }
    }
 
-   void Raster::writeToFile(const std::string path) const
+   void Raster::writeToFile(const std::string &path) const
    {
 
       auto ext = fs::path(path).extension();
@@ -161,6 +161,11 @@ namespace KiLib
       return point;
    }
 
+   size_t Raster::flattenIndex(size_t r, size_t c)
+   {
+      return r * this->nCols + c;
+   }
+
    size_t Raster::getNearestCell(const KiLib::Vec3 &pos)
    {
       double rF = (pos.y - this->yllcorner) / this->cellsize;
@@ -174,8 +179,8 @@ namespace KiLib
 
    KiLib::Vec3 Raster::getCellPos(size_t ind)
    {
-      size_t r = this->nCols / ind;
-      size_t c = this->nCols % ind;
+      size_t r = ind / this->nCols;
+      size_t c = ind % this->nCols;
 
       KiLib::Vec3 pos = KiLib::Vec3(this->xllcorner + c * this->cellsize, this->yllcorner + r * this->cellsize, 0);
       pos.z           = this->getInterpBilinear(pos);

--- a/KiLib/Raster/Raster.cpp
+++ b/KiLib/Raster/Raster.cpp
@@ -259,4 +259,48 @@ namespace KiLib
       return slope;
    }
 
+   double Raster::GetAverage(size_t ind, double radius)
+   {
+      if (ind >= this->nData)
+      {
+         throw std::out_of_range(fmt::format("Index {} out of range for Raster with {} datapoints", ind, this->nData));
+      }
+
+      int r      = ind / this->nCols;
+      int c      = ind % this->nCols;
+      int extent = std::floor(radius / this->cellsize);
+
+      int leftB  = std::clamp(c - extent, 0, (int)this->nCols - 1);
+      int rightB = std::clamp(c + extent, 0, (int)this->nCols - 1);
+      int upB    = std::clamp(r + extent, 0, (int)this->nRows - 1);
+      int lowB   = std::clamp(r - extent, 0, (int)this->nRows - 1);
+
+      double sum = 0.0;
+      double num = 0.0;
+      for (int ri = lowB; ri <= upB; ri++)
+      {
+         for (int ci = leftB; ci <= rightB; ci++)
+         {
+            // Skip nodata
+            if (this->at(ri, ci) == this->nodata_value)
+            {
+               continue;
+            }
+            // this can probably be done faster, handles the corners being out of the radius
+            const double dr   = std::abs((double)(r - ri)) * cellsize;
+            const double dc   = std::abs((double)(c - ci)) * cellsize;
+            const double dist = sqrt(dr * dr + dc * dc);
+            if (dist > radius)
+            {
+               fmt::print("SKIPPING\n");
+               continue;
+            }
+            sum += this->at(ri, ci);
+            num += 1;
+         }
+      }
+
+      return sum / num;
+   }
+
 } // namespace KiLib

--- a/KiLib/Raster/Raster.cpp
+++ b/KiLib/Raster/Raster.cpp
@@ -292,7 +292,7 @@ namespace KiLib
             const double dist = sqrt(dr * dr + dc * dc);
             if (dist > radius)
             {
-               fmt::print("SKIPPING\n");
+               SPDLOG_DEBUG("SKIPPING\n");
                continue;
             }
             sum += this->at(ri, ci);

--- a/KiLib/Raster/Raster.hpp
+++ b/KiLib/Raster/Raster.hpp
@@ -261,23 +261,14 @@ namespace KiLib
        */
       template <class T>
       static KiLib::Raster Rasterize(
-         const KiLib::Raster &ref, const std::vector<T> &objs, KiLib::Vec3 T::*posP, double T::*attrP,
-         std::function<bool(const T &)> doPopulate)
+         const KiLib::Raster &ref, const std::vector<T> &objs, std::function<KiLib::Vec3(T)> getPos,
+         std::function<double(T)> getAttr)
       {
          KiLib::Raster            outRast = KiLib::Raster::fillLike(ref, 0.0, true);
          std::map<size_t, double> counts;
 
-         // Set up getters for the attributes
-         auto getPos  = std::bind(posP, std::placeholders::_1);
-         auto getAttr = std::bind(attrP, std::placeholders::_1);
-
          for (auto &obj : objs)
          {
-            if (!doPopulate(obj))
-            {
-               continue;
-            }
-
             KiLib::Vec3 pos  = getPos(obj);
             double      attr = getAttr(obj);
 

--- a/KiLib/Raster/Raster.hpp
+++ b/KiLib/Raster/Raster.hpp
@@ -57,7 +57,7 @@ namespace KiLib
 
       bool constructed; // Flag indicating whether a file was loaded
 
-      Raster(std::string path);
+      Raster(const std::string &path);
       Raster();
 
       // Creates a raster filled with zeros with same metadata as other.
@@ -76,7 +76,7 @@ namespace KiLib
          return new_;
       }
 
-      void writeToFile(const std::string path) const;
+      void writeToFile(const std::string &path) const;
 
       /**
        * @brief Prints basic information about this Raster
@@ -89,6 +89,11 @@ namespace KiLib
        * Returns flat index to nearest cell in raster
        */
       size_t getNearestCell(const KiLib::Vec3 &pos);
+
+      /**
+       * Returns flat index to nearest cell in raster
+       */
+      size_t flattenIndex(size_t r, size_t c);
 
       KiLib::Vec3 getCellPos(size_t ind);
 

--- a/KiLib/Raster/Raster.hpp
+++ b/KiLib/Raster/Raster.hpp
@@ -286,6 +286,8 @@ namespace KiLib
          return outRast;
       }
 
+      double GetAverage(size_t ind, double radius);
+
    private:
       void fromDEM(const std::string path);
       void fromTiff(const std::string path);

--- a/KiLib/Raster/Raster.test.cpp
+++ b/KiLib/Raster/Raster.test.cpp
@@ -61,7 +61,7 @@ namespace KiLib
 
       fs::current_path(path);
 
-      for (auto it : fs::directory_iterator(path))
+      for (const auto &it : fs::directory_iterator(path))
       {
          std::string base = (path / fs::path(it.path().stem().string())).string();
          files.insert(std::make_pair<std::string, std::string>(base + ".tif", base + ".dem"));
@@ -82,7 +82,7 @@ namespace KiLib
 
       fs::current_path(path);
 
-      for (auto it : fs::directory_iterator(path))
+      for (const auto &it : fs::directory_iterator(path))
       {
          if (!it.is_regular_file() && it.path().extension() != ".tif")
             continue;
@@ -113,7 +113,7 @@ namespace KiLib
 
       fs::current_path(path);
 
-      for (auto it : fs::directory_iterator(path))
+      for (const auto &it : fs::directory_iterator(path))
       {
          if (!it.is_regular_file() && it.path().extension() != ".tif")
             continue;
@@ -144,7 +144,7 @@ namespace KiLib
 
       fs::current_path(path);
 
-      for (auto it : fs::directory_iterator(path))
+      for (const auto &it : fs::directory_iterator(path))
       {
          if (!it.is_regular_file() && it.path().extension() != ".tif")
             continue;
@@ -175,7 +175,7 @@ namespace KiLib
 
       fs::current_path(path);
 
-      for (auto it : fs::directory_iterator(path))
+      for (const auto &it : fs::directory_iterator(path))
       {
          if (!it.is_regular_file() && it.path().extension() != ".tif")
             continue;
@@ -207,7 +207,7 @@ namespace KiLib
 
       fs::current_path(path);
 
-      for (std::string size : sizes)
+      for (const std::string &size : sizes)
       {
          std::string base = (path / size).string();
 
@@ -219,4 +219,33 @@ namespace KiLib
       }
    }
 
+   TEST(Raster, getCellPos)
+   {
+      auto                     cwd  = fs::current_path();
+      auto                     path = fs::path(std::string(TEST_DIRECTORY) + "/ComputeSlope/");
+      std::vector<std::string> sizes{"5x5", "7x7", "7x3"};
+
+      fs::current_path(path);
+
+      for (const std::string &size : sizes)
+      {
+         std::string base = (path / size).string();
+
+         Raster dem(base + ".dem");
+         for (size_t r = 0; r < dem.nRows; r++)
+         {
+            for (size_t c = 0; c < dem.nCols; c++)
+            {
+               size_t      ind = dem.flattenIndex(r, c);
+               KiLib::Vec3 pos = dem.getCellPos(ind);
+               double      z   = dem.at(r, c);
+
+               ASSERT_DOUBLE_EQ(pos.z, z);
+               ASSERT_DOUBLE_EQ(pos.y, dem.yllcorner + (double)r * dem.cellsize);
+               ASSERT_DOUBLE_EQ(pos.x, dem.xllcorner + (double)c * dem.cellsize);
+               ASSERT_EQ(ind, dem.getNearestCell(pos));
+            }
+         }
+      }
+   }
 } // namespace KiLib

--- a/KiLib/Raster/Raster.test.cpp
+++ b/KiLib/Raster/Raster.test.cpp
@@ -302,4 +302,21 @@ namespace KiLib
       ASSERT_DOUBLE_EQ(rasterizedTrunc(1, 1), 1.0);
       ASSERT_DOUBLE_EQ(rasterizedTrunc(0, 0), 1.0);
    }
+
+
+   TEST(Raster, GetAverage)
+   {
+      auto   cwd  = fs::current_path();
+      auto   path = fs::path(std::string(TEST_DIRECTORY) + "/ComputeSlope/7x3_NODATA.dem");
+      Raster dem(path.string());
+
+      double avg1 = dem.GetAverage(0, 4.0);
+      ASSERT_DOUBLE_EQ(avg1, 6.0);
+
+      double avg2 = dem.GetAverage(4, 1.0);
+      ASSERT_DOUBLE_EQ(avg2, 4.0);
+
+      double avg3 = dem.GetAverage(14, 2.0);
+      ASSERT_DOUBLE_EQ(avg3, 13.5);
+   }
 } // namespace KiLib

--- a/KiLib/Raster/Raster.test.cpp
+++ b/KiLib/Raster/Raster.test.cpp
@@ -248,4 +248,47 @@ namespace KiLib
          }
       }
    }
+
+   TEST(Raster, Rasterize)
+   {
+      class TestClass
+      {
+      public:
+         TestClass(KiLib::Vec3 pos, double safetyFactor)
+         {
+            this->pos          = pos;
+            this->safetyFactor = safetyFactor;
+         }
+
+         KiLib::Vec3 pos;
+         double      safetyFactor;
+      };
+
+      auto                   cwd  = fs::current_path();
+      auto                   path = fs::path(std::string(TEST_DIRECTORY) + "/ComputeSlope/7x3_NODATA.dem");
+      Raster                 dem(path.string());
+      std::vector<TestClass> objs{
+         {{0.4, 0.3, -1.0}, 0.03},  // 0, 0
+         {{0.1, 0.49, -1.0}, 0.12}, // 0, 0
+         {{0.5, 0.5, -1.0}, 0.3},   // 1, 1
+         {{1.2, 5.1, -1.0}, 0.7},   // 5, 1
+         {{0.9, 4.6, -1.0}, 0.3},   // 5, 1
+         {{1.4, 4.6, -1.0}, 1.1},   // 5, 1
+      };
+
+      //clang-format off
+      KiLib::Raster rasterized = KiLib::Raster::Rasterize<TestClass>(
+         dem,                      // Reference dem to construct sizes
+         objs,                     // Our vector of objects to rasterize
+         &TestClass::pos,          // Our objects position attribute
+         &TestClass::safetyFactor, // Our objects attribute to rasterize
+         [](const auto &obj) {
+            return true;
+         } // Function to determine whether or not to rasterize (i.e. check if safety factor < 1.0)
+      );
+      //clang-format on
+
+      rasterized.print();
+      dem.print();
+   }
 } // namespace KiLib

--- a/KiLib/Soils/SoilType.hpp
+++ b/KiLib/Soils/SoilType.hpp
@@ -21,7 +21,6 @@
 #pragma once
 
 #include <assert.h>
-#define _USE_MATH_DEFINES
 #include <cmath>
 #include <filesystem>
 #include <iostream>

--- a/test/ComputeSlope/7x3.dem
+++ b/test/ComputeSlope/7x3.dem
@@ -1,0 +1,13 @@
+ncols        3
+nrows        7
+xllcorner    1.0
+yllcorner    2.0
+cellsize     2.0
+NODATA_value  -99999
+18 19 20 
+15 16 17 
+12 13 14 
+9  10 11 
+6  7  8 
+3  4  5 
+0  1  2

--- a/test/ComputeSlope/7x3_NODATA.dem
+++ b/test/ComputeSlope/7x3_NODATA.dem
@@ -1,0 +1,13 @@
+ncols        3
+nrows        7
+xllcorner    0.0
+yllcorner    0.0
+cellsize     1.0
+NODATA_value  -99999
+18 19     20 
+15 16     17 
+12 -99999 14 
+9  10     11 
+6  7      8 
+3  4      5 
+0  1      2


### PR DESCRIPTION
Fixes divide by zero in KiLib::Raster::getCellPos, adds function flattenIndex that flattens a 2d index into 1d. Adds robust test.

Adds function to rasterize data.

Closes #57
Closes #56
Closes #59 