### PR TITLE
Improved raster interpolation, add matrix class

### DIFF
--- a/KiLib/Raster/Raster.cpp
+++ b/KiLib/Raster/Raster.cpp
@@ -54,45 +54,26 @@ namespace KiLib
    // Takes in a vec3 for convenience, ignores Z
    double Raster::getInterpBilinear(const Vec3 &pos) const
    {
-      double r = std::clamp<double>((pos.y - this->yllcorner) / this->cellsize, 0.0, (double)this->nRows - 1);
-      double c = std::clamp<double>((pos.x - this->xllcorner) / this->cellsize, 0.0, (double)this->nCols - 1);
+      double x = (pos.x - this->xllcorner) / this->cellsize;
+      double y = (pos.y - this->yllcorner) / this->cellsize;
 
-      if (r == floor(r) && c == floor(c))
-      {
-         return this->at(r, c);
-      }
+      const size_t r = std::floor(y);
+      const size_t c = std::floor(x);
+      
+      const size_t ru  = std::min(r+1ul, this->nRows-1ul);
+      const size_t cr  = std::min(c+1ul, this->nCols-1ul);
 
-      const double y1  = floor(r) * this->cellsize;
-      const double y2  = ceil(r) * this->cellsize;
-      const double x1  = floor(c) * this->cellsize;
-      const double x2  = ceil(c) * this->cellsize;
-      const double q11 = this->operator()(floor(r), floor(c));
-      const double q12 = this->operator()(ceil(r), floor(c));
-      const double q21 = this->operator()(floor(r), ceil(c));
-      const double q22 = this->operator()(ceil(r), ceil(c));
-
-      const double x = c * this->cellsize;
-      const double y = r * this->cellsize;
-
-      double fy1 = q12;
-      double fy2 = q11;
-      if (x2 != x1)
-      {
-         fy1 = ((x2 - x) / (x2 - x1)) * q11 + ((x - x1) / (x2 - x1)) * q21;
-         fy2 = ((x2 - x) / (x2 - x1)) * q12 + ((x - x1) / (x2 - x1)) * q22;
-      }
-
-      double z = 0;
-      if (y2 != y1)
-      {
-         z = ((y2 - y) / (y2 - y1)) * fy1 + ((y - y1) / (y2 - y1)) * fy2;
-      }
-      else
-      {
-         z = (fy1 + fy2) / 2.0;
-      }
-
-      return z;
+      const double f00 = this->operator()(r, c);
+      const double f10 = this->operator()(r, cr);
+      const double f01 = this->operator()(ru, c);
+      const double f11 = this->operator()(ru, cr);
+      
+      const double sx = x - std::floor(x);
+      const double sy = y - std::floor(y);
+      
+      const double val = f00*(1.0-sx)*(1.0-sy) + f10*sx*(1.0-sy) + f01*(1.0-sx)*sy + f11*sx*sy;
+      
+      return val;
    }
 
    // Print Raster metadata

--- a/KiLib/Raster/Raster.test.cpp
+++ b/KiLib/Raster/Raster.test.cpp
@@ -109,6 +109,28 @@ namespace KiLib
       }
    }
 
+   TEST(Raster, getInterpBilinear)
+   {
+      auto                     cwd  = fs::current_path();
+      auto                     path = fs::path(std::string(TEST_DIRECTORY) + "/ComputeSlope/");
+
+      fs::current_path(path);
+
+      Raster dem("5x5.dem");
+      KiLib::Vec3 p1{780099.2947926898, 205426.59516664856, 1909.8001915739701};
+      KiLib::Vec3 p2{780099.3343145008, 205427.51547149016, 1910.3570077815384};
+      KiLib::Vec3 p3{780096.0843788842, 205427.65816391885, 1910.520074732899};
+
+      double z1 = dem(p1);
+      ASSERT_DOUBLE_EQ(z1, p1.z);
+
+      double z2 = dem(p2);
+      ASSERT_DOUBLE_EQ(z2, p2.z);
+      
+      double z3 = dem(p3);
+      ASSERT_DOUBLE_EQ(z3, p3.z);
+   }
+
    TEST(Raster, Rasterize)
    {
       class TestClass


### PR DESCRIPTION
I've improved the bilinear interpolation code in the Raster class. I'm using the unit square method described here
[https://www.wikiwand.com/en/Bilinear_interpolation#/On_the_unit_square](https://www.wikiwand.com/en/Bilinear_interpolation#/On_the_unit_square)
![image](https://user-images.githubusercontent.com/9584084/127788548-25d9bfcc-b6d7-4931-ac2d-9e9086a3da68.png)

By transforming the relevant points to conform to this unit square implementation, we can handle collapsing into the 1D case without a branch (as in, the relevant polynomial weights of f(i,j) will collapse to 0 when a point we are interpolating over is on a grid line between raster points).

It definitely improved throughput in SOSlope a bit.

**It is important to understand that any package that utilizes the interpolation feature of rasters will have different output now (hopefully quite small)**.

