### PR TITLE
cmake: added guard to prevent custom target name collision between projects

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,7 +86,10 @@ if (NOT COSCI_PROJECT_NAME OR COSCI_PROJECT_NAME STREQUAL "")
     set(COSCI_PROJECT_NAME "kilib-oss" CACHE STRING "" FORCE)
 endif()
 
-add_custom_target(push_to_repo
-	COMMAND bash ${CMAKE_SOURCE_DIR}/CMake/gen_oras_config.sh > oras_config.json
-	COMMAND oras push harbor.nibious.com/cosci-llc/${COSCI_PROJECT_NAME}:$ENV{GO_REVISION_GIT}-${CMAKE_BUILD_TYPE}-$ENV{OS_RELEASE} --config oras_config.json libKiLib.a
-)
+# Only add this target if we're not being included as a subproject
+if( CMAKE_SOURCE_DIR STREQUAL CMAKE_CURRENT_SOURCE_DIR )
+    add_custom_target(push_to_repo
+        COMMAND bash ${CMAKE_SOURCE_DIR}/CMake/gen_oras_config.sh > oras_config.json
+        COMMAND oras push harbor.nibious.com/cosci-llc/${COSCI_PROJECT_NAME}:$ENV{GO_REVISION_GIT}-${CMAKE_BUILD_TYPE}-$ENV{OS_RELEASE} --config oras_config.json libKiLib.a
+    )
+endif()


### PR DESCRIPTION
was getting cmake error when trying to build kilib:
```
CMake Error at build/kilib_proj/CMakeLists.txt:66 (add_custom_target):
  add_custom_target cannot create target "push_to_repo" because another
  target with the same name already exists.  The existing target is a custom
  target created in source directory
  "/Users/dev/projects/slideformap/build/kilib_proj/build/kilib_proj".  See
  documentation for policy CMP0002 for more details.
```

I fixed this issue by making it so that only the top-level project will be allowed to have a `push_to_repo` custom target defined. this avoids the name conflict problem. we need to do this for kilib non-open source too